### PR TITLE
Added custom_footer.html for Micro.blog.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,5 +7,6 @@
     <body>
     {{ end }}
         {{ block "main" . }}{{ end }}
+	{{ partial "custom_footer.html" . }}
     </body>
 </html>


### PR DESCRIPTION
When Micro.blog users use the "Edit Footer" button, Micro.blog overwrites this template so it needs to be included.